### PR TITLE
Sandiego.org Event dates formatter module ready for issue #5

### DIFF
--- a/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
+++ b/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
@@ -1,21 +1,24 @@
 /**
  * 
- *  [Filename] 
+ * @module addons/EventDatesFormatter
  * 
- *  /web-scrapers/sandiego.org/addons/EventDatesFormatter.js
- *  
- *  [Description]
- *  
- *  Small addon module plugin that ../app.js calls after obtaining event data results
- *  from sandiego.org. This module updates each returned event and formats dates for 
- *  ISO 8601 (YYYY-MM-DDDD) standard. 
+ * @description 
+ * Small addon module plugin for sandiego.org event scraper used inside ../app.js 
+ * after obtaining event data results. This module updates each returned event and 
+ * formats dates for ISO 8601 (YYYY-MM-DDDD) standard.
+ *
+ * @param {Object[]} scrapedData - The array of of events pulled from sandiego.org.
+ * @param {callback(Array)} callback - The callback that handles the newly created date formatted events array.
+ * @returns {Object[]} scrapedDataDateFormatted - Array of updated sandiego.org event objects with date formatting. 
+ */
+
+/* 
+ * The module makes the following changes to each object in the input array:
  * 
- *  The module makes the following changes to each object in the input array:
- * 
- *      event.original_dates [Added] - (Contains the original data from event.dates)
- *      event.dates [Removed] - (Removed from object and set on event.original_dates property)
- *      event.start_date [Added] - (Contains the start date of event in ISO 8601)
- *      event.end_date [Added] - (Contains the end date of event in ISO 8601)
+ * - event.original_dates [Added] - (Contains the original data from event.dates)
+ * - event.dates [Removed] - (Removed from object and set on event.original_dates property)
+ * - event.start_date [Added] - (Contains the start date of event in ISO 8601)
+ * - event.end_date [Added] - (Contains the end date of event in ISO 8601)
  * 
  *  [References]
  * 
@@ -86,10 +89,10 @@ module.exports = (scrapedData, callback)=>{
 
         // Final cleanup 
 
-        delete event.dates // Remove from object already set on [original_dates] property above.
+        delete event.dates // Remove dates property. We already duplicated as [original_dates] property above.
 
         // Return the updated event object
-
+        
         return event;
 
     });

--- a/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
+++ b/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
@@ -1,0 +1,87 @@
+/**
+ * 
+ *  [Filename] 
+ * 
+ *  /web-scrapers/sandiego.org/addons/EventDatesFormatter.js
+ *  
+ *  [Description]
+ *  
+ *  Small addon module plugin that ../app.js calls after obtaining event data results
+ *  from sandiego.org. This module updates each returned event and formats dates for 
+ *  ISO 8601 (YYYY-MM-DDDD) standard. 
+ * 
+ *  The module makes the following changes to each object in the input array:
+ * 
+ *      event.original_date [Added] - (Contains the original data from event.date)
+ *      event.dates [Modified] - (Contains the start date of event in ISO 8601)
+ *      event.end_date [Added] - (Contains the end date of event in ISO 8601)
+ * 
+ */
+
+var moment = require('moment');
+
+module.exports = (scrapedData, callback)=>{
+    
+    var currentDate = moment().format('YYYY-MM-DD');
+    var scrapedDataDateFormatted = scrapedData.map(event=>{
+    
+        event.original_date = event.dates;
+        
+        let datesSplitString = event.dates.split('-')
+            
+        // If we can split the date range then we will perform additional logic
+
+        if(datesSplitString.length > 1){ 
+
+            let datesSplitStringEndDate = datesSplitString[datesSplitString.length-1].trim();
+            let datesSplitStringStartDate = datesSplitString[0].trim();
+    
+            /*  
+                If date range format then the first date needs year added 
+                to make ISO 8601 date formatting easier Check if the start date contains YYYY
+            */
+
+            if(!datesSplitStringStartDate.match(',')){
+                
+                let YYYY = null;
+
+                if(datesSplitStringEndDate === 'ongoing'){
+                    YYYY = moment().year();
+                } else{
+                    YYYY = moment(datesSplitStringEndDate, 'MMM DD, YYYY').format('YYYY');
+                    datesSplitStringStartDate += `, ${YYYY}`;  
+                }
+
+            }
+
+            let formattedStartDate = moment(datesSplitStringStartDate,'MMM DD, YYYY').format('YYYY-MM-DD');
+            
+            /*
+                Check if the start date is after current date of this scraper execution process
+                If this is true then set the date property of object to the ISO formatted start date.
+                If false then we will set the property to todays date.
+            */
+
+            if(moment(formattedStartDate).isAfter(currentDate)){
+                event.dates = formattedStartDate;
+            } else {
+                event.dates = currentDate;
+            }
+                                  
+            if(datesSplitStringEndDate !== 'ongoing'){
+                event.end_date = moment(datesSplitStringEndDate, 'MMM DD, YYYY').format('YYYY-MM-DD');
+            } else {
+                event.end_date = datesSplitStringEndDate;
+            }
+            
+        } else {
+            event.dates = moment(event.dates, 'MMM DD, YYYY').format('YYYY-MM-DD');
+            event.end_date = '';        
+        }
+
+        return event;
+
+    });
+
+    callback(scrapedDataDateFormatted);
+}

--- a/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
+++ b/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
@@ -12,9 +12,14 @@
  * 
  *  The module makes the following changes to each object in the input array:
  * 
- *      event.original_date [Added] - (Contains the original data from event.dates)
- *      event.dates [Modified] - (Contains the start date of event in ISO 8601)
+ *      event.original_dates [Added] - (Contains the original data from event.dates)
+ *      event.dates [Removed] - (Removed from object and set on event.original_dates property)
+ *      event.start_date [Added] - (Contains the start date of event in ISO 8601)
  *      event.end_date [Added] - (Contains the end date of event in ISO 8601)
+ * 
+ *  [References]
+ * 
+ *  1. https://github.com/mnich0ls/evee-sd/issues/5
  * 
  */
 
@@ -25,7 +30,7 @@ module.exports = (scrapedData, callback)=>{
     var currentDate = moment().format('YYYY-MM-DD');
     var scrapedDataDateFormatted = scrapedData.map(event=>{
     
-        event.original_date = event.dates;
+        event.original_dates = event.dates;
         
         let datesSplitString = event.dates.split('-')
             
@@ -63,9 +68,9 @@ module.exports = (scrapedData, callback)=>{
             */
 
             if(moment(formattedStartDate).isAfter(currentDate)){
-                event.dates = formattedStartDate;
+                event.start_date = formattedStartDate;
             } else {
-                event.dates = currentDate;
+                event.start_date = currentDate;
             }
                                   
             if(datesSplitStringEndDate !== 'ongoing'){
@@ -75,9 +80,15 @@ module.exports = (scrapedData, callback)=>{
             }
             
         } else {
-            event.dates = moment(event.dates, 'MMM DD, YYYY').format('YYYY-MM-DD');
-            event.end_date = '';        
+            event.start_date = moment(event.dates, 'MMM DD, YYYY').format('YYYY-MM-DD');
+            event.end_date = 0;        
         }
+
+        // Final cleanup 
+
+        delete event.dates // Remove from object already set on [original_dates] property above.
+
+        // Return the updated event object
 
         return event;
 

--- a/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
+++ b/web-scrapers/sandiego.org/addons/EventDatesFormatter.js
@@ -12,7 +12,7 @@
  * 
  *  The module makes the following changes to each object in the input array:
  * 
- *      event.original_date [Added] - (Contains the original data from event.date)
+ *      event.original_date [Added] - (Contains the original data from event.dates)
  *      event.dates [Modified] - (Contains the start date of event in ISO 8601)
  *      event.end_date [Added] - (Contains the end date of event in ISO 8601)
  * 

--- a/web-scrapers/sandiego.org/app.js
+++ b/web-scrapers/sandiego.org/app.js
@@ -6,6 +6,11 @@ const axios = require('axios')
 
 const config = require('./config.json');
 
+// Load add-ons
+const addons = {
+    EventDatesFormatter: require('./addons/EventDatesFormatter')
+}
+
 // Authentication [Basic Auth] middleware
 
 app.use((req, res, next) => {
@@ -34,11 +39,13 @@ app.get('/scrape/events', (req, res) => {
             t: 'e'
         }
     }).then(response=>{
-        axios.put(
-            `${config.db.firebase.databaseURL}/scraped_events.json?auth=${config.db.firebase.authSecret}`, 
-            JSON.stringify(response.data.results)
-        ).then(()=>{
-            res.json(200);
+        addons.EventDatesFormatter(response.data.results, resultsDateFormatted =>{
+            axios.put(
+                `${config.db.firebase.databaseURL}/scraped_events.json?auth=${config.db.firebase.authSecret}`, 
+                JSON.stringify(resultsDateFormatted)
+            ).then(()=>{
+                res.json(200);
+            });
         });
     }).catch(err=>{
         res.status(500).json({ error: err})

--- a/web-scrapers/sandiego.org/package.json
+++ b/web-scrapers/sandiego.org/package.json
@@ -1,17 +1,18 @@
 {
-    "name": "evee-sd-sandiego-org-scraper",
-    "version": "0.0.1",
-    "description": "",
-    "main": "app.js",
-    "dependencies": {
-      "axios": "^0.18.0",
-      "express": "^4.16.4"
-    },
-    "devDependencies": {},
-    "scripts": {
-      "start": "node app.js",
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "",
-    "license": "ISC"
-  }
+  "name": "evee-sd-sandiego-org-scraper",
+  "version": "0.0.1",
+  "description": "",
+  "main": "app.js",
+  "dependencies": {
+    "axios": "^0.18.0",
+    "express": "^4.16.4",
+    "moment": "^2.24.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "start": "node app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Small addon module plugin for sandiego.org event scraper used inside ../app.js after obtaining event data results. This module updates each returned event and formats dates for ISO 8601 (YYYY-MM-DDDD) standard.